### PR TITLE
multicore: don't enable timer interrupts on secondary cores

### DIFF
--- a/zephyr/lib/cpu.c
+++ b/zephyr/lib/cpu.c
@@ -48,7 +48,6 @@ static FUNC_NORETURN void secondary_init(void *arg)
 		k_busy_wait(100);
 
 	z_smp_thread_init(arg, &dummy_thread);
-	smp_timer_init();
 
 	secondary_core_init(sof_get());
 


### PR DESCRIPTION
Keep timer interrupt handling on the primary core, this avoids secondary cores failing to handle timer interrupts immediately after power on.